### PR TITLE
(MAINT) Fix issue template and config

### DIFF
--- a/.github/ISSUE_TEMPLATE/99-plan-maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/99-plan-maintenance.yml
@@ -3,8 +3,6 @@ description: >-
   Submit a work item to track non-trivial maintenance work. This is for my own to use. You
   probably don't want to submit an issue with this form.
 
-title: ''
-
 labels:
   - maintenance
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,10 +5,10 @@ contact_links:
     about: If you want to discuss a specific post, look for it in the linked discussions.
   - name: Ask a question
     url: https://github.com/michaeltlombardi/mikeywrites.fyi/discussions/categories/q-a
-    about: If you'd like to ask Mikey or other readers a question, do so in GitHub discussions.
+    about: If you'd like to ask me or other readers a question, do so in GitHub discussions.
   - name: Start a conversation
     url: https://github.com/michaeltlombardi/mikeywrites.fyi/discussions/categories/chat
     about: You can also start a general conversation in GitHub discussions.
   - name: Check news from Mikey
     url: https://github.com/michaeltlombardi/mikeywrites.fyi/discussions/categories/tidings
-    about: Mikey occasionally posts news that doesn't make sense as a blog post in GitHub discussions.
+    about: I occasionally post news that doesn't make sense as a blog post in GitHub discussions.


### PR DESCRIPTION
Prior to this change, the planned maintenance issue template didn't show up in the issue picker because the YAML defined `title` as an empty string, which is invalid for the template schema. Further, the issue template configuration used a mix of first and third person when referring to me.

This change:

- Removes `title` from the planned maintenace issue template.
- Standardizes on first person for the configuration.