### PR TITLE
(MAINT) Enable multiple categories for planned maint

### DIFF
--- a/.github/ISSUE_TEMPLATE/99-plan-maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/99-plan-maintenance.yml
@@ -26,6 +26,7 @@ body:
         - Theme
         - Site
         - Posts
+      multiple: true
   - type: textarea
     id: context
     validations: { required: true }


### PR DESCRIPTION
Prior to this change, the issue template for planned maintenance didn't set the `multiple` field for the `category` input to `true`, so any planned maintenance work item could only apply to a single category.

Some planned maintenance touches multiple categories, so the issue template should support doing so.

This change adds the missing field to ensure the issue template supports multiple categories for planned maintenance work.